### PR TITLE
Add localization for Config backup

### DIFF
--- a/language-pack/src/main/res/values/general.xml
+++ b/language-pack/src/main/res/values/general.xml
@@ -74,6 +74,12 @@
     <string name="update_info_updated">Update successfully installed!</string>
     <string name="update_info_latest">No new updates available</string>
 
+    <!-- Config Backup/Restore -->
+    <string name="config_backup_info_success">Successfully exported the options file</string>
+    <string name="config_backup_info_fail">Failed to export the options file</string>
+    <string name="config_backup_restore_info_success">Successfully imported the options file</string>
+    <string name="config_backup_restore_info_fail">Failed to import the options file</string>
+
 <!-- All new strings should present below for better managing locals... -->
 
 </resources>

--- a/language-pack/src/main/res/values/settings.xml
+++ b/language-pack/src/main/res/values/settings.xml
@@ -58,6 +58,13 @@
     <string name="opt_update_title">Check for updates</string>
     <string name="opt_update_summary">Check for available updates</string>
 
+    <!-- Config Backup -->
+    <string name="opt_category_config_backup">Backup</string>
+    <string name="opt_config_backup_title">Export options file</string>
+    <string name="opt_config_backup_summary">Exports non-sensitive options to \"osudroid.cfg\" in osu!droid\'s main directory</string>
+    <string name="opt_config_backup_restore_title">Import options file</string>
+    <string name="opt_config_backup_restore_summary">Imports non-sensitive options from \"osudroid.cfg\" in osu!droid\'s main directory</string>
+
 <!-- Gameplay -->
     <!-- Skin -->
     <string name="opt_category_skin">Skin</string>


### PR DESCRIPTION
I plan on opening a PR on the main repo with https://github.com/kairusds/osu-droid/tree/options-export and it requires new localization data from the language pack