### PR TITLE
Translate UI strings to Indonesian (formal, consistent)

### DIFF
--- a/language-pack/src/main/res/values-id/dialogs.xml
+++ b/language-pack/src/main/res/values-id/dialogs.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="dialog_exit_yes">Yes</string>
-    <string name="dialog_exit_no">No</string>
-    <string name="dialog_exit_message">Are you sure you want to exit the game?</string>
+    <string name="dialog_exit_yes">Ya</string>
+    <string name="dialog_exit_no">Tidak</string>
+    <string name="dialog_exit_message">Apakah Anda yakin ingin keluar dari permainan?</string>
 
-    <string name="dialog_visit_osu_website">Do you want to visit the official osu! website?</string>
-    <string name="dialog_visit_osudroid_profile_page">Do you want to visit your profile page?</string>
-    <string name="dialog_visit_osudroid_website">Do you want to visit the official osu!droid website?</string>
+    <string name="dialog_visit_osu_website">Apakah Anda ingin mengunjungi situs resmi osu!?</string>
+    <string name="dialog_visit_osudroid_profile_page">Apakah Anda ingin mengunjungi halaman profil Anda?</string>
+    <string name="dialog_visit_osudroid_website">Apakah Anda ingin mengunjungi situs resmi osu!droid?</string>
 
-    <string name="hudEditor_modal_title">HUD Editor</string>
-    <string name="hudEditor_modal_save">Exit and save changes</string>
-    <string name="hudEditor_modal_discard">Discard changes</string>
-    <string name="hudEditor_modal_reset">Reset to default</string>
-    <string name="hudEditor_modal_cancel">Cancel</string>
+    <string name="hudEditor_modal_title">Editor HUD</string>
+    <string name="hudEditor_modal_save">Keluar dan simpan perubahan</string>
+    <string name="hudEditor_modal_discard">Buang perubahan</string>
+    <string name="hudEditor_modal_reset">Atur ulang ke default</string>
+    <string name="hudEditor_modal_cancel">Batal</string>
 
-    <string name="hudEditor_back_for_menu">Press back to show HUD editor menu.</string>
-    <string name="hudEditor_saving">Saving changes...</string>
-    <string name="hudEditor_saved">Changes saved!</string>
-    <string name="hudEditor_discarded">Changes discarded!</string>
-    <string name="hudEditor_reset">HUD set to default!</string>
+    <string name="hudEditor_back_for_menu">Tekan kembali untuk menampilkan menu editor HUD.</string>
+    <string name="hudEditor_saving">Menyimpan perubahan...</string>
+    <string name="hudEditor_saved">Perubahan berhasil disimpan!</string>
+    <string name="hudEditor_discarded">Perubahan dibuang!</string>
+    <string name="hudEditor_reset">HUD dikembalikan ke default!</string>
 
-    <string name="config_backup_info_success">Successfully exported the options file</string>
-    <string name="config_backup_info_fail">Failed to export the options file</string>
-    <string name="config_backup_restore_info_success">Successfully imported the options file</string>
-    <string name="config_backup_restore_info_fail">Failed to import the options file</string>
+    <string name="config_backup_info_success">Berhasil mengekspor file opsi</string>
+    <string name="config_backup_info_fail">Gagal mengekspor file opsi</string>
+    <string name="config_backup_restore_info_success">Berhasil mengimpor file opsi</string>
+    <string name="config_backup_restore_info_fail">Gagal mengimpor file opsi</string>
 
 <!-- All new strings should present below for better managing locals... -->
 

--- a/language-pack/src/main/res/values-id/general.xml
+++ b/language-pack/src/main/res/values-id/general.xml
@@ -1,78 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="markdown_title">Markdown Title</string>
-    <string name="changelog_title">Changelog</string>
+    <string name="markdown_title">Judul Markdown</string>
+    <string name="changelog_title">Catatan rilis</string>
 
-    <string name="message_info_multitouch">Multitouch may not be supported by your device</string>
-    <string name="message_low_storage_space">Storage space is low. Free Storage: %s GB. This may cause replay/score submission bugs.</string>
+    <string name="message_info_multitouch">Multitouch mungkin tidak didukung oleh perangkat Anda</string>
+    <string name="message_low_storage_space">Ruang penyimpanan rendah. Ruang bebas: %s GB. Ini dapat menyebabkan masalah pada replay/submisi skor.</string>
 
-    <string name="message_error">Error: %s</string>
-    <string name="message_error_open">Cannot open %s</string>
-    <string name="message_error_createdir">Cannot create %s</string>
-    <string name="message_error_sdcard">External storage is not mounted</string>
-    <string name="message_error_sdcardread">External storage is read only</string>
-    <string name="message_video_custom_speed_unsupported">Custom video playback speed is not supported in this device</string>
+    <string name="message_error">Kesalahan: %s</string>
+    <string name="message_error_open">Tidak dapat membuka %s</string>
+    <string name="message_error_createdir">Tidak dapat membuat %s</string>
+    <string name="message_error_sdcard">Penyimpanan eksternal tidak terpasang</string>
+    <string name="message_error_sdcardread">Penyimpanan eksternal hanya bisa dibaca</string>
+    <string name="message_video_custom_speed_unsupported">Kecepatan pemutaran video kustom tidak didukung di perangkat ini</string>
 
     <!-- Crash -->
-    <string name="crash">Sorry, the game encountered an unexpected error and needs to close.</string>
+    <string name="crash">Maaf, permainan mengalami kesalahan tak terduga dan harus ditutup.</string>
 
     <!-- Accessibility -->
-    <string name="accessibility_detector_title">Disable Accessibility Services</string>
-    <string name="accessibility_detector_message">The following accessibility services must be disabled in order to play:</string>
-    <string name="accessibility_detector_settings">Go to accessibility settings</string>
-    <string name="accessibility_detector_exit">Exit game</string>
+    <string name="accessibility_detector_title">Nonaktifkan Layanan Aksesibilitas</string>
+    <string name="accessibility_detector_message">Layanan aksesibilitas berikut harus dinonaktifkan agar dapat bermain:</string>
+    <string name="accessibility_detector_settings">Buka pengaturan aksesibilitas</string>
+    <string name="accessibility_detector_exit">Keluar dari game</string>
 
     <!-- Online -->
-    <string name="online_loadrecord">Loading record details...</string>
-    <string name="multiplayer_not_online">You must be logged in to the server to play multiplayer!</string>
+    <string name="online_loadrecord">Memuat detail rekor...</string>
+    <string name="multiplayer_not_online">Anda harus masuk ke server untuk bermain multiplayer!</string>
 
     <!-- Color Picker -->
-    <string name="press_color_to_apply">Press on Color to apply</string>
+    <string name="press_color_to_apply">Tekan warna untuk menerapkan</string>
 
     <!-- Beatmap downloader -->
-    <string name="beatmap_downloader_cancel">Cancel</string>
-    <string name="beatmap_downloader_connecting">Connecting to server...</string>
-    <string name="beatmap_downloader_downloading">Downloading beatmap %s...</string>
-    <string name="beatmap_downloader_importing">Importing beatmap %s...</string>
+    <string name="beatmap_downloader_cancel">Batal</string>
+    <string name="beatmap_downloader_connecting">Menghubungkan ke server...</string>
+    <string name="beatmap_downloader_downloading">Mengunduh beatmap %s...</string>
+    <string name="beatmap_downloader_importing">Mengimpor beatmap %s...</string>
 
     <!-- Ranked status -->
     <string name="ranked_status_ranked"><font color="#41FF64">Ranked</font></string>
-    <string name="ranked_status_approved"><font color="#41FF64">Approved</font></string>
-    <string name="ranked_status_qualified"><font color="#64F2FF">Qualified</font></string>
-    <string name="ranked_status_loved"><font color="#FA64FF">Loved</font></string>
-    <string name="ranked_status_pending"><font color="#FFAC64">Pending</font></string>
-    <string name="ranked_status_wip"><font color="#FFAC64">Work in Progress</font></string>
-    <string name="ranked_status_graveyard"><font color="#FFFFFF">Graveyard</font></string>
+    <string name="ranked_status_approved"><font color="#41FF64">Disetujui</font></string>
+    <string name="ranked_status_qualified"><font color="#64F2FF">Qualifikasi</font></string>
+    <string name="ranked_status_loved"><font color="#FA64FF">Disukai</font></string>
+    <string name="ranked_status_pending"><font color="#FFAC64">Menunggu</font></string>
+    <string name="ranked_status_wip"><font color="#FFAC64">Sedang dikerjakan</font></string>
+    <string name="ranked_status_graveyard"><font color="#FFFFFF">Pemakaman</font></string>
 
     <!-- Library -->
-    <string name="library_cleared">Cache cleared</string>
-    <string name="library_importing">Importing beatmap...</string>
-    <string name="library_importing_several">Found %s archived beatmaps. Importing...</string>
-    <string name="library_skin_importing_several">Found %s archived skins. Importing...</string>
-    <string name="library_imported">\"%s\" has been imported!</string>
-    <string name="message_loaded_skin">Successfully applied new skin!</string>
-    <string name="message_error_dir_not_found">Directory is not found</string>
-    <string name="file_integrity_tampered">File integrity check failed. Aborting gameplay.</string>
+    <string name="library_cleared">Cache berhasil dibersihkan</string>
+    <string name="library_importing">Mengimpor beatmap...</string>
+    <string name="library_importing_several">Ditemukan %s beatmap terarsip. Mengimpor...</string>
+    <string name="library_skin_importing_several">Ditemukan %s tema terarsip. Mengimpor...</string>
+    <string name="library_imported">\"%s\" telah berhasil diimpor!</string>
+    <string name="message_loaded_skin">Tema baru berhasil diterapkan!</string>
+    <string name="message_error_dir_not_found">Direktori tidak ditemukan</string>
+    <string name="file_integrity_tampered">Pemeriksaan integritas file gagal. Permainan dihentikan.</string>
 
     <!-- Parser -->
-    <string name="beatmap_parser_cannot_open_file" formatted="false">Failed loading %s: Could not open beatmap file</string>
+    <string name="beatmap_parser_cannot_open_file" formatted="false">Gagal memuat %s: Tidak dapat membuka file beatmap</string>
 
     <!-- Block area manager fragment -->
-    <string name="block_area_editor_fragment_add">Add area</string>
-    <string name="block_area_editor_fragment_reset">Reset</string>
-    <string name="block_area_editor_fragment_done">Done</string>
+    <string name="block_area_editor_fragment_add">Tambah area</string>
+    <string name="block_area_editor_fragment_reset">Atur ulang</string>
+    <string name="block_area_editor_fragment_done">Selesai</string>
 
     <!-- Updater -->
-    <string name="update_dialog_message">There is a new update available</string>
-    <string name="update_dialog_button_update">Update Now</string>
-    <string name="update_info_checking">Checking for new updates...</string>
-    <string name="update_info_check_failed">Failed to check for updates. The server or your internet connection may not be available.</string>
-    <string name="update_info_downloading">Downloading updates... %d%%</string>
-    <string name="update_info_download_canceled">Download cancelled.</string>
-    <string name="update_info_download_failed">Download failed, check your internet connection.</string>
-    <string name="update_info_updated">Update successfully installed!</string>
-    <string name="update_info_latest">No new updates available</string>
+    <string name="update_dialog_message">Tersedia pembaruan baru</string>
+    <string name="update_dialog_button_update">Perbarui Sekarang</string>
+    <string name="update_info_checking">Memeriksa pembaruan baru...</string>
+    <string name="update_info_check_failed">Gagal memeriksa pembaruan. Server atau koneksi internet Anda mungkin tidak tersedia.</string>
+    <string name="update_info_downloading">Mengunduh pembaruan... %d%%</string>
+    <string name="update_info_download_canceled">Unduhan dibatalkan.</string>
+    <string name="update_info_download_failed">Unduhan gagal, periksa koneksi internet Anda.</string>
+    <string name="update_info_updated">Pembaruan berhasil diinstal!</string>
+    <string name="update_info_latest">Tidak ada pembaruan baru tersedia</string>
 
 <!-- All new strings should present below for better managing locals... -->
 

--- a/language-pack/src/main/res/values-id/menus.xml
+++ b/language-pack/src/main/res/values-id/menus.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Song Select -->
-    <string name="menu_score" formatted="false">Score: %s (%dx)</string>
-    <string name="menu_performance" formatted="false">Performance: %spp (%dx)</string>
-    <string name="menu_creator">Creator: %s</string>
+    <string name="menu_score" formatted="false">Skor: %s (%dx)</string>
+    <string name="menu_performance" formatted="false">Performa: %spp (%dx)</string>
+    <string name="menu_creator">Pembuat: %s</string>
 
-    <string name="menu_mod_back">Back</string>
-    <string name="menu_mod_multiplier" formatted="false">Score %.2fx</string>
-    <string name="menu_mod_reset">Reset all mods</string>
+    <string name="menu_mod_back">Kembali</string>
+    <string name="menu_mod_multiplier" formatted="false">Skor %.2fx</string>
+    <string name="menu_mod_reset">Atur ulang semua mod</string>
 
-    <string name="menu_properties_title">Song properties</string>
-    <string name="menu_properties_offset">Song offset:</string>
-    <string name="menu_properties_tofavs">Add to favorites</string>
-    <string name="menu_properties_delete">Delete beatmap</string>
+    <string name="menu_properties_title">Properti lagu</string>
+    <string name="menu_properties_offset">Offset lagu:</string>
+    <string name="menu_properties_tofavs">Tambahkan ke favorit</string>
+    <string name="menu_properties_delete">Hapus beatmap</string>
 
-    <string name="menu_deletescore_delete">Delete</string>
-    <string name="menu_deletescore_delete_success">Delete score success!</string>
+    <string name="menu_deletescore_delete">Hapus</string>
+    <string name="menu_deletescore_delete_success">Hapus skor berhasil!</string>
 
-    <string name="menu_search_filter">Search for...</string>
-    <string name="menu_search_sort_title">Title</string>
-    <string name="menu_search_sort_date">Date</string>
-    <string name="menu_search_sort_creator">Creator</string>
-    <string name="menu_search_sort_artist">Artist</string>
-    <string name="menu_search_sort_bpm">Bpm</string>
-    <string name="menu_search_sort_droid_stars">osu!droid Stars</string>
-    <string name="menu_search_sort_standard_stars">osu!standard Stars</string>
-    <string name="menu_search_sort_length">Length</string>
-    <string name="binfoStr1" formatted="false">Length: %s BPM: %s Combo: %d</string>
-    <string name="binfoStr2" formatted="false">Circles: %d Sliders: %d Spinners: %d (MapId: %d)</string>
+    <string name="menu_search_filter">Cari...</string>
+    <string name="menu_search_sort_title">Judul</string>
+    <string name="menu_search_sort_date">Tanggal</string>
+    <string name="menu_search_sort_creator">Pembuat</string>
+    <string name="menu_search_sort_artist">Artis</string>
+    <string name="menu_search_sort_bpm">BPM</string>
+    <string name="menu_search_sort_droid_stars">bintang osu!droid</string>
+    <string name="menu_search_sort_standard_stars">bintang osu!standard</string>
+    <string name="menu_search_sort_length">Durasi</string>
+    <string name="binfoStr1" formatted="false">Durasi: %s BPM: %s Combo: %d</string>
+    <string name="binfoStr2" formatted="false">Lingkaran: %d Slider: %d Spinner: %d (MapId: %d)</string>
     <!-- End Song Select -->
 
     <!-- Filter Menu -->
     <string name="favorite_default">Default</string>
-    <string name="favorite_new_folder">Create new folder</string>
-    <string name="favorite_ensure">Are you sure?</string>
-    <string name="favorite_manage">Manage Beatmap folder</string>
+    <string name="favorite_new_folder">Buat folder baru</string>
+    <string name="favorite_ensure">Apakah Anda yakin?</string>
+    <string name="favorite_manage">Kelola folder beatmap</string>
 
 
 <!-- Score Export/Import -->
-    <string name="frg_score_menu_title">Score</string>
-    <string name="frg_score_menu_export_score">Export Score</string>
-    <string name="frg_score_menu_export_failed">Failed to export replay!</string>
-    <string name="frg_score_menu_export_succeed" formatted="true">Replay is saved to %s</string>
+    <string name="frg_score_menu_title">Skor</string>
+    <string name="frg_score_menu_export_score">Ekspor Skor</string>
+    <string name="frg_score_menu_export_failed">Gagal mengekspor replay!</string>
+    <string name="frg_score_menu_export_succeed" formatted="true">Replay disimpan ke %s</string>
 
     <!-- Mod Menu -->
-    <string name="mod_section_difficulty_reduction">Difficulty Reduction</string>
-    <string name="mod_section_difficulty_increase">Difficulty Increase</string>
-    <string name="mod_section_difficulty_automation">Automation</string>
-    <string name="mod_section_difficulty_conversion">Conversion</string>
-    <string name="mod_section_fun">Fun</string>
-    <string name="mod_section_system">System</string>
+    <string name="mod_section_difficulty_reduction">Reduksi kesulitan</string>
+    <string name="mod_section_difficulty_increase">Peningkatan kesulitan</string>
+    <string name="mod_section_difficulty_automation">Otomatisasi</string>
+    <string name="mod_section_difficulty_conversion">Konversi</string>
+    <string name="mod_section_fun">Menyenangkan</string>
+    <string name="mod_section_system">Sistem</string>
 
     <!-- Game Loading -->
-    <string name="opt_show_scoreboard_title">Show Scoreboard</string>
-    <string name="epilepsy_warning">This beatmap contains scenes with rapidly flashing colors.\nPlease take caution if you are affected by epilepsy.</string>
+    <string name="opt_show_scoreboard_title">Tampilkan papan skor</string>
+    <string name="epilepsy_warning">Beatmap ini mengandung adegan dengan warna berkedip cepat.\nHarap berhati-hati jika Anda menderita epilepsi.</string>
 
 <!-- All new strings should present below for better managing locals... -->
 

--- a/language-pack/src/main/res/values-id/multiplayer.xml
+++ b/language-pack/src/main/res/values-id/multiplayer.xml
@@ -2,41 +2,41 @@
 <resources>
 
 <!-- Details -->
-    <string name="mp_room_category_details">Details</string>
+    <string name="mp_room_category_details">Rincian</string>
 
-    <string name="mp_room_name_title">Room name</string>
-    <string name="mp_room_name_summary">Change the room\'s name.</string>
+    <string name="mp_room_name_title">Nama ruangan</string>
+    <string name="mp_room_name_summary">Ubah nama ruangan.</string>
 
-    <string name="mp_room_password_title">Room password</string>
-    <string name="mp_room_password_summary">Change the room\'s password. If empty, the room will be public.</string>
+    <string name="mp_room_password_title">Kata sandi ruangan</string>
+    <string name="mp_room_password_summary">Ubah kata sandi ruangan. Jika kosong, ruangan akan bersifat publik.</string>
 
-    <string name="mp_room_max_players_title">Maximum Players</string>
-    <string name="mp_room_max_players_summary">Set the maximum number of players allowed in the room</string>
+    <string name="mp_room_max_players_title">Jumlah pemain maksimal</string>
+    <string name="mp_room_max_players_summary">Atur jumlah pemain maksimal yang diperbolehkan di ruangan</string>
 
     <!-- Variables -->
-    <string name="mp_room_category_variables">Variables</string>
+    <string name="mp_room_category_variables">Variabel</string>
 
-    <string name="mp_room_free_mods_title">Enable free mods</string>
-    <string name="mp_room_free_mods_summary">Allow players to choose mods except speed-changing mods.</string>
+    <string name="mp_room_free_mods_title">Aktifkan mod bebas</string>
+    <string name="mp_room_free_mods_summary">Izinkan pemain memilih mod kecuali mod perubahan kecepatan.</string>
 
-    <string name="mp_room_versus_mode_title">Team mode</string>
-    <string name="mp_room_versus_mode_summary">Change the room versus mode.</string>
+    <string name="mp_room_versus_mode_title">Mode tim</string>
+    <string name="mp_room_versus_mode_summary">Ubah mode versus ruangan.</string>
     <string-array name="mp_team_versus_names">
         <item>Head to Head</item>
-        <item>Team vs Team</item>
+        <item>Tim vs Tim</item>
     </string-array>
     <string-array name="mp_team_versus_values">
         <item>0</item>
         <item>1</item>
     </string-array>
 
-    <string name="mp_room_win_condition_title">Win condition</string>
-    <string name="mp_room_win_condition_summary">Change the room win condition.</string>
+    <string name="mp_room_win_condition_title">Kondisi kemenangan</string>
+    <string name="mp_room_win_condition_summary">Ubah kondisi kemenangan ruangan.</string>
     <string-array name="mp_win_condition_names">
-        <item>Score V1</item>
-        <item>Accuracy</item>
-        <item>Max combo</item>
-        <item>Score V2</item>
+        <item>Skor V1</item>
+        <item>Akurasi</item>
+        <item>Kombo maksimum</item>
+        <item>Skor V2</item>
     </string-array>
     <string-array name="mp_win_condition_values">
         <item>0</item>
@@ -46,21 +46,21 @@
     </string-array>
 
     <!-- Share -->
-    <string name="mp_room_category_share">Share</string>
+    <string name="mp_room_category_share">Bagikan</string>
 
-    <string name="mp_room_link_title">Get invite link</string>
-    <string name="mp_room_link_summary">Copy invite link to clipboard</string>
+    <string name="mp_room_link_title">Dapatkan tautan undangan</string>
+    <string name="mp_room_link_summary">Salin tautan undangan ke clipboard</string>
 
 
 <!-- Multiplayer Player Settings -->
     <!-- Team -->
-    <string name="mp_room_category_teams">Team</string>
+    <string name="mp_room_category_teams">Tim</string>
 
-    <string name="mp_room_category_teams_title">Team</string>
-    <string name="mp_room_category_teams_summary">Change your team.</string>
+    <string name="mp_room_category_teams_title">Tim</string>
+    <string name="mp_room_category_teams_summary">Ubah tim Anda.</string>
     <string-array name="mp_team_names">
-        <item>Red</item>
-        <item>Blue</item>
+        <item>Merah</item>
+        <item>Biru</item>
     </string-array>
     <string-array name="mp_team_values">
         <item>0</item>
@@ -68,45 +68,45 @@
     </string-array>
 
     <!-- In Game -->
-    <string name="mp_room_category_in_game">In-game</string>
+    <string name="mp_room_category_in_game">Dalam permainan</string>
 
-    <string name="mp_room_enable_score_submission_title">Enable score submission</string>
-    <string name="mp_room_enable_score_submission_summary">Submit your score at the end of the round if you did not fail</string>
+    <string name="mp_room_enable_score_submission_title">Aktifkan pengiriman skor</string>
+    <string name="mp_room_enable_score_submission_summary">Kirim skor Anda di akhir putaran jika Anda tidak gagal</string>
 
-    <string name="mp_room_nightcore_title">Use NightCore</string>
-    <string name="mp_room_nightcore_summary">Enable NightCore mod instead when DoubleTime is enabled</string>
+    <string name="mp_room_nightcore_title">Gunakan NightCore</string>
+    <string name="mp_room_nightcore_summary">Aktifkan mod NightCore sebagai ganti DoubleTime saat diaktifkan</string>
 
 
 <!-- Multiplayer Lobby -->
-    <string name="multiplayer_lobby_back">Back</string>
-    <string name="multiplayer_lobby_create_room">Create room</string>
-    <string name="multiplayer_lobby_create_room_accept">Create</string>
-    <string name="multiplayer_lobby_create_room_cancel">Cancel</string>
+    <string name="multiplayer_lobby_back">Kembali</string>
+    <string name="multiplayer_lobby_create_room">Buat ruangan</string>
+    <string name="multiplayer_lobby_create_room_accept">Buat</string>
+    <string name="multiplayer_lobby_create_room_cancel">Batal</string>
     <string name="multiplayer_lobby_create_room_name_default">%s\'s room</string>
-    <string name="multiplayer_lobby_refresh">Refresh</string>
-    <string name="multiplayer_lobby_no_rooms">No rooms available, create a new one!</string>
-    <string name="multiplayer_lobby_no_results">No results found for the current search.</string>
-    <string name="multiplayer_lobby_fetch_error_toast">Failed to obtain rooms: %s</string>
-    <string name="multiplayer_lobby_fetch_error">Failed to obtain rooms</string>
-    <string name="multiplayer_lobby_room_name">Room name</string>
-    <string name="multiplayer_lobby_room_password">Room password</string>
-    <string name="multiplayer_lobby_room_capacity">Room capacity</string>
-    <string name="multiplayer_lobby_join_room">Join room</string>
-    <string name="multiplayer_lobby_join_room_accept">Join</string>
-    <string name="multiplayer_lobby_join_room_cancel">Cancel</string>
+    <string name="multiplayer_lobby_refresh">Perbarui</string>
+    <string name="multiplayer_lobby_no_rooms">Tidak ada ruangan tersedia, buat yang baru!</string>
+    <string name="multiplayer_lobby_no_results">Tidak ditemukan hasil untuk pencarian saat ini.</string>
+    <string name="multiplayer_lobby_fetch_error_toast">Gagal mengambil ruangan: %s</string>
+    <string name="multiplayer_lobby_fetch_error">Gagal mengambil ruangan</string>
+    <string name="multiplayer_lobby_room_name">Nama ruangan</string>
+    <string name="multiplayer_lobby_room_password">Kata sandi ruangan</string>
+    <string name="multiplayer_lobby_room_capacity">Kapasitas ruangan</string>
+    <string name="multiplayer_lobby_join_room">Masuk ke ruangan</string>
+    <string name="multiplayer_lobby_join_room_accept">Masuk</string>
+    <string name="multiplayer_lobby_join_room_cancel">Batal</string>
     <string name="multiplayer_room_head_to_head">Head to head</string>
-    <string name="multiplayer_room_team_versus">Team versus</string>
-    <string name="multiplayer_room_players">Players</string>
-    <string name="multiplayer_room_score_v1">Score V1</string>
-    <string name="multiplayer_room_score_v2">Score V2</string>
-    <string name="multiplayer_room_status_idle">Idle</string>
-    <string name="multiplayer_room_status_changing_beatmap">Changing beatmap</string>
-    <string name="multiplayer_room_status_playing">Playing</string>
-    <string name="multiplayer_room_highest_accuracy">Highest accuracy</string>
-    <string name="multiplayer_room_maximum_combo">Maximum combo</string>
-    <string name="multiplayer_room_no_players">No players</string>
-    <string name="multiplayer_room_free_mods">Free mods</string>
-    <string name="multiplayer_lobby_search_rooms">Search rooms...</string>
+    <string name="multiplayer_room_team_versus">Tim versus</string>
+    <string name="multiplayer_room_players">Pemain</string>
+    <string name="multiplayer_room_score_v1">Skor V1</string>
+    <string name="multiplayer_room_score_v2">Skor V2</string>
+    <string name="multiplayer_room_status_idle">Menganggur</string>
+    <string name="multiplayer_room_status_changing_beatmap">Mengganti beatmap</string>
+    <string name="multiplayer_room_status_playing">Bermain</string>
+    <string name="multiplayer_room_highest_accuracy">Akurasi tertinggi</string>
+    <string name="multiplayer_room_maximum_combo">Kombo maksimum</string>
+    <string name="multiplayer_room_no_players">Tidak ada pemain</string>
+    <string name="multiplayer_room_free_mods">Mod bebas</string>
+    <string name="multiplayer_lobby_search_rooms">Cari ruangan...</string>
 
 <!-- All new strings should present below for better managing locals... -->
 

--- a/language-pack/src/main/res/values-id/replay.xml
+++ b/language-pack/src/main/res/values-id/replay.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Import -->
-    <string name="act_import_replay">Import replay into osu!droid</string>
-    <string name="invalid_edr_file">Invalid repay!</string>
-    <string name="failed_to_import_edr">Failed to import replay!</string>
-    <string name="failed_to_import_edr_with_err" formatted="true">Failed to import replay: %s</string>
-    <string name="import_edr_successfully">Import replay successfully!</string>
+    <string name="act_import_replay">Impor replay ke osu!droid</string>
+    <string name="invalid_edr_file">Replay tidak valid!</string>
+    <string name="failed_to_import_edr">Gagal mengimpor replay!</string>
+    <string name="failed_to_import_edr_with_err" formatted="true">Gagal mengimpor replay: %s</string>
+    <string name="import_edr_successfully">Replay berhasil diimpor!</string>
 
-    <string name="replay_import_result">Imported %d out of %d replay(s)!</string>
-    <string name="replay_import_error">Unable to import %s: %s</string>
+    <string name="replay_import_result">Berhasil mengimpor %d dari %d replay!</string>
+    <string name="replay_import_error">Gagal mengimpor %s: %s</string>
 
     <!-- Save -->
-    <string name="message_save_replay_successful">Save failed replay success!</string>
-    <string name="message_save_replay_failed">Save replay failed</string>
+    <string name="message_save_replay_successful">Simpan replay gagal berhasil!</string>
+    <string name="message_save_replay_failed">Simpan replay gagal</string>
 
-    <string name="replay_invalid">Cannot load replay</string>
-    <string name="replay_cantdownload">Cannot download replay</string>
-    <string name="replay_wrongmap">Replay doesn\'t match the map</string>
-    <string name="replay_corrupted">Replay file is corrupted</string>
+    <string name="replay_invalid">Tidak dapat memuat replay</string>
+    <string name="replay_cantdownload">Tidak dapat mengunduh replay</string>
+    <string name="replay_wrongmap">Replay tidak cocok dengan map</string>
+    <string name="replay_corrupted">File replay rusak</string>
 
 <!-- All new strings should present below for better managing locals... -->
 

--- a/language-pack/src/main/res/values-id/settings.xml
+++ b/language-pack/src/main/res/values-id/settings.xml
@@ -9,25 +9,25 @@
 <!-- General -->
     <!-- Online-->
     <string name="opt_category_online">Online</string>
-    <string name="opt_stayonline_title">Koneksi server</string>
+    <string name="opt_stayonline_title">Koneksi Server</string>
     <string name="opt_stayonline_summary">Sambungkan ke server osu!droid</string>
 
-    <string name="opt_loadavatar_title">Muat avatar</string>
+    <string name="opt_loadavatar_title">Muat Avatar</string>
     <string name="opt_loadavatar_summary">Muat tanpa koneksi Wi-Fi</string>
 
-    <string name="opt_global_beatmap_leaderboard_scoring_mode_title">Global beatmap leaderboard scoring mode</string>
-    <string name="opt_global_beatmap_leaderboard_scoring_mode_summary">Choose the scoring mode for global beatmap leaderboards</string>
+    <string name="opt_global_beatmap_leaderboard_scoring_mode_title">Mode penilaian papan peringkat beatmap global</string>
+    <string name="opt_global_beatmap_leaderboard_scoring_mode_summary">Pilih mode penilaian untuk papan peringkat beatmap global</string>
     <string-array name="global_beatmap_leaderboard_scoring_mode_names">
-        <item>Score</item>
-        <item>Performance Points</item>
+        <item>Skor</item>
+        <item>Poin Performa</item>
     </string-array>
     <string-array name="global_beatmap_leaderboard_scoring_mode_values">
         <item>0</item>
         <item>1</item>
     </string-array>
 
-    <string name="difficulty_algorithm_title">Difficulty algorithm</string>
-    <string name="difficulty_algorithm_summary">Choose the algorithm used to calculate difficulty and performance points</string>
+    <string name="difficulty_algorithm_title">Algoritma kesulitan</string>
+    <string name="difficulty_algorithm_summary">Pilih algoritma yang digunakan untuk menghitung tingkat kesulitan dan poin performa</string>
     <string-array name="difficulty_algorithm_names">
         <item>osu!droid</item>
         <item>osu!standard</item>
@@ -38,45 +38,45 @@
     </string-array>
 
     <!-- Account -->
-    <string name="opt_category_account">Account</string>
+    <string name="opt_category_account">Akun</string>
     <string name="opt_login_title">Masuk</string>
-    <string name="opt_login_summary">Nama daring Anda</string>
+    <string name="opt_login_summary">Nama pengguna Anda</string>
 
-    <string name="opt_password_title">Kata sandi</string>
+    <string name="opt_password_title">Kata Sandi</string>
     <string name="opt_password_summary">Kata sandi akun Anda</string>
 
     <string name="opt_register_title">Daftar</string>
-    <string name="opt_register_summary">Daftarkan akun baru (Anda hanya boleh membuat satu akun untuk setiap perangkat)</string>
+    <string name="opt_register_summary">Daftarkan akun baru (Anda hanya bisa membuat satu akun per perangkat)</string>
 
     <!-- Community-->
-    <string name="opt_category_community">Community</string>
+    <string name="opt_category_community">Komunitas</string>
     <string name="opt_receive_announcements_title">Receive announcements</string>
     <string name="opt_receive_announcements_summary">Receive notifications of announcements, events, etc.</string>
 
     <!-- Updates -->
-    <string name="opt_category_updates">Updates</string>
-    <string name="opt_update_title">Cek untuk pembaruan</string>
-    <string name="opt_update_summary">Cek untuk pembaruan yang ada</string>
+    <string name="opt_category_updates">Pembaruan</string>
+    <string name="opt_update_title">Periksa pembaruan</string>
+    <string name="opt_update_summary">Cek apakah ada pembaruan yang tersedia</string>
 
     <!-- Config Backup -->
-    <string name="opt_category_config_backup">Backup</string>
-    <string name="opt_config_backup_title">Export options file</string>
-    <string name="opt_config_backup_summary">Exports non-sensitive options to \"osudroid.cfg\" in osu!droid\'s main directory</string>
-    <string name="opt_config_backup_restore_title">Import options file</string>
-    <string name="opt_config_backup_restore_summary">Imports non-sensitive options from \"osudroid.cfg\" in osu!droid\'s main directory</string>
+    <string name="opt_category_config_backup">Cadangan</string>
+    <string name="opt_config_backup_title">Ekspor file opsi</string>
+    <string name="opt_config_backup_summary">Ekspor opsi non-sensitif ke file "osudroid.cfg" di direktori utama osu!droid</string>
+    <string name="opt_config_backup_restore_title">Impor file opsi</string>
+    <string name="opt_config_backup_restore_summary">Impor opsi non-sensitif dari file "osudroid.cfg" di direktori utama osu!droid</string>
 
     <!-- Localization -->
-    <string name="opt_category_localization">Localization</string>
-    <string name="opt_language_title">Language</string>
-    <string name="opt_language_summary">Change the language of the game. Requires a restart.</string>
+    <string name="opt_category_localization">Lokalisasi</string>
+    <string name="opt_language_title">Bahasa</string>
+    <string name="opt_language_summary">Ubah bahasa permainan. Perlu restart.</string>
 
 <!-- Gameplay -->
     <!-- Skin -->
-    <string name="opt_category_skin">Skin</string>
-    <string name="opt_skinpath_title">Pilih tema</string>
-    <string name="opt_skinpath_summary">Pilih tema dari direktori tema di atas</string>
+    <string name="opt_category_skin">Tema</string>
+    <string name="opt_skinpath_title">Pilih Tema</string>
+    <string name="opt_skinpath_summary">Pilih tema dari direktori tema yang tersedia</string>
 
-    <string name="opt_spinner_style_title">Model spinner</string>
+    <string name="opt_spinner_style_title">Gaya Spinner</string>
     <string name="opt_spinner_style_summary">Ubah model spinner</string>
     <string-array name="spinner_style_names">
         <item>Modern</item>
@@ -87,133 +87,133 @@
         <item>0</item>
     </string-array>
 
-    <string name="opt_skin_title">Tema beatmap</string>
-    <string name="opt_skin_summary">Muat tema spesifik dalam beatmap jika ada</string>
+    <string name="opt_skin_title">Tema Beatmap</string>
+    <string name="opt_skin_summary">Muat tema khusus pada beatmap jika tersedia</string>
 
     <!-- Hit Objects-->
-    <string name="opt_category_hit_objects">Hit objects</string>
-    <string name="opt_show_first_approach_circle_title">Perlihatkan approach circle pertama</string>
-    <string name="opt_show_first_approach_circle_summary">Jangan sembunyikan approach circle pertama dalam mod Hidden</string>
+    <string name="opt_category_hit_objects">Objek Pukulan</string>
+    <string name="opt_show_first_approach_circle_title">Tampilkan lingkaran pendekatan pertama</string>
+    <string name="opt_show_first_approach_circle_summary">Jangan sembunyikan lingkaran pendekatan pertama saat menggunakan mod Hidden</string>
 
     <!-- Background -->
-    <string name="opt_category_background">Background</string>
-    <string name="opt_bgbrightness_title">Pencerahan latar belakang</string>
-    <string name="opt_bgbrightness_summary">Ubah kecerahan gambar latar belakang</string>
+    <string name="opt_category_background">Latar Belakang</string>
+    <string name="opt_bgbrightness_title">Kecerahan Latar Belakang</string>
+    <string name="opt_bgbrightness_summary">Atur kecerahan gambar latar belakang</string>
 
-    <string name="opt_keep_background_aspect_ratio_title">Keep background aspect ratio</string>
-    <string name="opt_keep_background_aspect_ratio_summary">When enabled, the background (and storyboard) will not be scaled to fill screen bounds during gameplay</string>
+    <string name="opt_keep_background_aspect_ratio_title">Pertahankan rasio aspek latar belakang</string>
+    <string name="opt_keep_background_aspect_ratio_summary">Bila diaktifkan, latar belakang (dan storyboard) tidak akan diperbesar untuk mengisi batas layar selama permainan.</string>
 
-    <string name="opt_enableStoryboard_title">Aktifkan storyboard</string>
+    <string name="opt_enableStoryboard_title">Aktifkan Storyboard</string>
 
-    <string name="opt_video_title">Background Video</string>
-    <string name="opt_video_summary">Display video playback during gameplay. Only supports .3gp, .mp4, .mkv, and .webm video formats</string>
+    <string name="opt_video_title">Video Latar Belakang</string>
+    <string name="opt_video_summary">Tampilkan pemutaran video selama permainan. Mendukung format .3gp, .mp4, .mkv, dan .webm</string>
 
     <!-- HUD -->
     <string name="opt_category_hud">HUD</string>
 
-    <string name="opt_hudEditor_title">HUD Editor</string>
-    <string name="opt_hudEditor_summary">Edit the HUD layout as you like</string>
+    <string name="opt_hudEditor_title">Editor HUD</string>
+    <string name="opt_hudEditor_summary">Sesuaikan tata letak HUD sesuai keinginan</string>
 
-    <string name="opt_hide_ingame_ui_title">Hide gameplay UI</string>
-    <string name="opt_hide_ingame_ui_summary">Hide the counters and other UIs during gameplay</string>
+    <string name="opt_hide_ingame_ui_title">Sembunyikan antarmuka permainan</string>
+    <string name="opt_hide_ingame_ui_summary">Sembunyikan indikator dan elemen antarmuka lainnya selama permainan</string>
 
-    <string name="opt_hide_replay_marquee_title">Hide replay marquee</string>
-    <string name="opt_hide_replay_marquee_summary">Hide the scrolling text when watching replays</string>
+    <string name="opt_hide_replay_marquee_title">Sembunyikan marquee replay</string>
+    <string name="opt_hide_replay_marquee_summary">Sembunyikan teks bergulir saat menonton replay</string>
 
     <string name="opt_fps_title">FPS</string>
-    <string name="opt_fps_summary">Tampilkan FPS sewaktu bermain</string>
+    <string name="opt_fps_summary">Tampilkan FPS selama bermain</string>
 
-    <string name="opt_display_score_statistics_title">Display score statistics</string>
-    <string name="opt_display_score_statistics_summary">Displays score statistics (star rating, PP, and more) in result screen</string>
+    <string name="opt_display_score_statistics_title">Tampilkan statistik skor</string>
+    <string name="opt_display_score_statistics_summary">Menampilkan statistik skor (peringkat bintang, PP, dan lainnya) pada layar hasil</string>
 
     <!-- Combo Colors-->
-    <string name="opt_combo_colors_title">Warna kombo</string>
-    <string name="opt_combo_colors_summary">Gunakan warna kombo yang telah ditentukan</string>
+    <string name="opt_combo_colors_title">Warna Combo</string>
+    <string name="opt_combo_colors_summary">Gunakan warna combo yang telah ditentukan</string>
 
     <!-- Playfield -->
-    <string name="opt_category_playfield">Playfield</string>
-    <string name="opt_setplayfield_title">Set playfield size</string>
-    <string name="opt_setplayfield_summary">Change the size of the playfield</string>
+    <string name="opt_category_playfield">Bidang Permainan</string>
+    <string name="opt_setplayfield_title">Atur ukuran bidang permainan</string>
+    <string name="opt_setplayfield_summary">Ubah ukuran bidang permainan</string>
 
-    <string name="opt_display_playfield_border_title">Display playfield border</string>
-    <string name="opt_display_playfield_border_summary">Displays a border around the playfield</string>
+    <string name="opt_display_playfield_border_title">Tampilkan batas bidang permainan</string>
+    <string name="opt_display_playfield_border_summary">Menampilkan garis batas di sekitar bidang permainan</string>
 
-    <string name="opt_playfieldHorizontalPosition_title">Horizontal position</string>
-    <string name="opt_playfieldHorizontalPosition_summary">Set the horizontal position (in percentage) of the playfield from the left corner of the screen</string>
+    <string name="opt_playfieldHorizontalPosition_title">Posisi horizontal</string>
+    <string name="opt_playfieldHorizontalPosition_summary">Atur posisi horizontal (dalam persentase) bidang permainan dari sudut kiri layar</string>
 
-    <string name="opt_playfieldVerticalPosition_title">Vertical position</string>
-    <string name="opt_playfieldVerticalPosition_summary">Set the vertical position (in percentage) of the playfield from the top of the screen</string>
+    <string name="opt_playfieldVerticalPosition_title">Posisi vertikal</string>
+    <string name="opt_playfieldVerticalPosition_summary">Atur posisi vertikal (dalam persentase) bidang permainan dari bagian atas layar</string>
 
 <!-- Graphics -->
     <!-- Cursor -->
-    <string name="opt_category_cursor">Cursor</string>
-    <string name="opt_showcursor_title">Perlihatkan kursor</string>
-    <string name="opt_showcursor_summary">Perlihatkan kursor di bawah jari saat permainan berlangsung</string>
+    <string name="opt_category_cursor">Kursor</string>
+    <string name="opt_showcursor_title">Tampilkan kursor</string>
+    <string name="opt_showcursor_summary">Tampilkan kursor di bawah jari saat permainan berlangsung</string>
 
     <string name="opt_cursor_size">Ukuran kursor</string>
-    <string name="opt_cursor_size_summary">Atur ukuran kursor (25 - 300, standar 100)</string>
+    <string name="opt_cursor_size_summary">Atur ukuran kursor (25 - 300; standar: 100)</string>
 
     <string name="opt_particles_title">Efek partikel</string>
-    <string name="opt_particles_summary">Perlihatkan efek berbasis partikel seperti jejak kursor</string>
+    <string name="opt_particles_summary">Tampilkan efek berbasis partikel seperti jejak kursor</string>
 
     <!-- Animations and Effects -->
-    <string name="opt_category_animations">Animations and effects</string>
-    <string name="opt_dim_hit_objects_title">Enable hit objects dim</string>
-    <string name="opt_dim_hit_objects_summary">Dim hit objects when they are ready to be hit.</string>
+    <string name="opt_category_animations">Animasi dan efek</string>
+    <string name="opt_dim_hit_objects_title">Redup objek pukulan</string>
+    <string name="opt_dim_hit_objects_summary">Redup objek pukulan saat siap untuk dipukul.</string>
 
-    <string name="opt_combo_burst_title">Burst kombo</string>
-    <string name="opt_combo_burst_summary">Aktifkan atau nonaktifkan burst kombo</string>
+    <string name="opt_combo_burst_title">Ledakan combo</string>
+    <string name="opt_combo_burst_summary">Aktifkan atau nonaktifkan ledakan combo</string>
 
     <string name="opt_largeimages_title">Hitung mundur</string>
-    <string name="opt_largeimages_summary">Tunjukkan hitung mundur dari awal map jika tersedia</string>
+    <string name="opt_largeimages_summary">Tampilkan hitung mundur dari awal map jika tersedia</string>
 
-    <string name="opt_animate_follow_circle_title">Animate follow circle</string>
-    <string name="opt_animate_follow_circle_summary">Enable slider follow circle animations when hitting/releasing follow circle.</string>
+    <string name="opt_animate_follow_circle_title">Animasikan lingkaran ikuti</string>
+    <string name="opt_animate_follow_circle_summary">Aktifkan animasi lingkaran ikuti slider saat memukul/melepaskan lingkaran ikuti.</string>
 
-    <string name="opt_animate_combo_text_title">Animate combo text</string>
-    <string name="opt_animate_combo_text_summary">Enable combo text shadow animation when increasing combo.</string>
+    <string name="opt_animate_combo_text_title">Animasikan teks combo</string>
+    <string name="opt_animate_combo_text_summary">Aktifkan animasi bayangan teks combo saat meningkatkan combo.</string>
 
-    <string name="opt_snakingInSliders_title">Use snaking in sliders</string>
-    <string name="opt_snakingInSliders_summary">Enable sliders gradually snaking from start</string>
+    <string name="opt_snakingInSliders_title">Gunakan gerakan gelombang pada slider</string>
+    <string name="opt_snakingInSliders_summary">Aktifkan slider secara bertahap bergerak meliuk dari awal</string>
 
-    <string name="opt_snakingOutSliders_title">Use snaking out sliders</string>
-    <string name="opt_snakingOutSliders_summary">Enable sliders gradually snaking disappearing from one node</string>
+    <string name="opt_snakingOutSliders_title">Gunakan gerakan gelombang keluar pada slider</string>
+    <string name="opt_snakingOutSliders_summary">Aktifkan slider secara bertahap bergerak meliuk keluar dari satu titik</string>
 
-    <string name="opt_noChangeDimInBreaks_title">Don\'t change background dim level during breaks</string>
-    <string name="opt_noChangeDimInBreaks_summary">When enabled, background dim level will not change during breaks.</string>
+    <string name="opt_noChangeDimInBreaks_title">Jangan ubah tingkat redup latar belakang selama istirahat</string>
+    <string name="opt_noChangeDimInBreaks_summary">Bila diaktifkan, tingkat redup latar belakang tidak akan berubah selama istirahat.</string>
 
-    <string name="opt_bursts_title">Efek meledak</string>
-    <string name="opt_bursts_summary">Perlihatkan efek meledak saat hit lingkaran atau slider</string>
+    <string name="opt_bursts_title">Efek ledakan</string>
+    <string name="opt_bursts_summary">Tampilkan efek ledakan saat memukul lingkaran atau slider</string>
 
-    <string name="opt_hitlighting_title">Pencahayaan hit</string>
-    <string name="opt_hitlighting_summary">Tambahkan cahaya halus yang menerangi area bermain di belakang ledakan hit</string>
+    <string name="opt_hitlighting_title">Pencahayaan pukulan</string>
+    <string name="opt_hitlighting_summary">Tambahkan cahaya lembut yang menerangi area permainan di belakang ledakan pukulan</string>
 
     <!-- Display -->
-    <string name="opt_category_display">Display</string>
+    <string name="opt_category_display">Tampilan</string>
     <string name="opt_hide_navibar_title">Bilah navigasi</string>
-    <string name="opt_hide_navibar_summary">Sembunyikan bilah navigasi ketika bermain</string>
+    <string name="opt_hide_navibar_summary">Sembunyikan bilah navigasi saat bermain</string>
 
 <!-- Audio -->
     <!-- Volume -->
     <string name="opt_category_volume">Volume</string>
-    <string name="opt_bgm_volume_title">BGM volume</string>
-    <string name="opt_bgm_volume_summary">Volume of the background music</string>
+    <string name="opt_bgm_volume_title">Volume BGM</string>
+    <string name="opt_bgm_volume_summary">Volume musik latar</string>
 
-    <string name="opt_sound_volume_title">Volume suara hit</string>
-    <string name="opt_sound_volume_summary">Besar volume suara hit (0-100)</string>
+    <string name="opt_sound_volume_title">Volume suara pukulan</string>
+    <string name="opt_sound_volume_summary">Besarnya volume suara pukulan (0–100)</string>
 
     <!-- Offset-->
     <string name="opt_category_offset">Offset</string>
-    <string name="opt_offset_title">Global offset</string>
-    <string name="opt_offset_summary">Offset musik dari ms (nilai positif berarti lebih awal)</string>
+    <string name="opt_offset_title">Offset global</string>
+    <string name="opt_offset_summary">Offset musik dari milidetik (nilai positif berarti lebih awal)</string>
 
-    <string name="opt_gameAudioSynchronizationThreshold_title">Minimum Synchronization Limit</string>
-    <string name="opt_gameAudioSynchronizationThreshold_summary">The minimum time difference (in milliseconds) between gameplay and audio for gameplay to attempt to synchronize with audio.\n\nA lower limit increases the frequency of the syncing attempt. If constant offset is preferred, use a higher limit.</string>
+    <string name="opt_gameAudioSynchronizationThreshold_title">Batas Sinkronisasi Minimum</string>
+    <string name="opt_gameAudioSynchronizationThreshold_summary">Batas perbedaan waktu minimum (dalam milidetik) antara gameplay dan audio agar gameplay mencoba menyinkronkan dengan audio.\n\nNilai yang lebih rendah meningkatkan frekuensi upaya penyinkronan. Jika offset konstan diinginkan, gunakan nilai yang lebih tinggi.</string>
 
     <!-- Metronome -->
-    <string name="opt_category_metronome">Metronome</string>
-    <string name="opt_metronome_switch_title">Metronome switch</string>
-    <string name="opt_metronome_switch_summary">Enable metronome sound effect</string>
+    <string name="opt_category_metronome">Metronom</string>
+    <string name="opt_metronome_switch_title">Sakelar metronom</string>
+    <string name="opt_metronome_switch_summary">Aktifkan efek suara metronom</string>
     <string-array name="metronome_switch_names">
         <item>Tidak aktif</item>
         <item>Hanya untuk mod NightCore</item>
@@ -226,87 +226,87 @@
     </string-array>
 
     <!-- Miscellaneous -->
-    <string name="opt_category_miscellaneous">Miscellaneous</string>
-    <string name="opt_sound_title">Beatmap sounds</string>
-    <string name="opt_sound_summary">Load beatmap-specific sounds if available</string>
+    <string name="opt_category_miscellaneous">Berbagai macam</string>
+    <string name="opt_sound_title">Suara beatmap</string>
+    <string name="opt_sound_summary">Muat suara spesifik beatmap jika tersedia</string>
 
-    <string name="opt_musicpreview_title">Tinjauan lagu</string>
-    <string name="opt_musicpreview_summary">Mainkan lagu ketika beatmap dipilih</string>
+    <string name="opt_musicpreview_title">Pratinjau lagu</string>
+    <string name="opt_musicpreview_summary">Putar lagu saat beatmap dipilih</string>
 
     <!-- Effect -->
-    <string name="opt_category_effect">Effect</string>
+    <string name="opt_category_effect">Efek</string>
 
-    <string name="opt_shiftPitchInRateChange_title">Shift pitch in rate-changing mods</string>
-    <string name="opt_shiftPitchInRateChange_summary">Shifts the pitch of the music when using rate-changing mods</string>
+    <string name="opt_shiftPitchInRateChange_title">Alihkan nada pada mod perubahan kecepatan</string>
+    <string name="opt_shiftPitchInRateChange_summary">Alihkan nada musik saat menggunakan mod perubahan kecepatan</string>
 
 <!-- Library -->
     <!-- Import -->
-    <string name="opt_category_import">Import</string>
+    <string name="opt_category_import">Impor</string>
     <string name="opt_deleteosz_title">Hapus .osz</string>
-    <string name="opt_deleteosz_summary">Hapus .osz setelah file diimpor</string>
+    <string name="opt_deleteosz_summary">Hapus file .osz setelah diimpor</string>
 
-    <string name="opt_scandownload_summary">Pindai direktori /Download untuk beatmap baru</string>
+    <string name="opt_scandownload_summary">Pindai direktori /Download untuk mencari beatmap baru</string>
     <string name="opt_scandownload_title">Pindai /Download</string>
 
-    <string name="opt_deleteUnimportedBeatmaps_title">Delete Unimported Beatmaps</string>
-    <string name="opt_deleteUnimportedBeatmaps_summary">Delete beatmaps that cannot be imported. Will apply in future beatmap import operations.</string>
+    <string name="opt_deleteUnimportedBeatmaps_title">Hapus beatmap yang tidak berhasil diimpor</string>
+    <string name="opt_deleteUnimportedBeatmaps_summary">Hapus beatmap yang tidak dapat diimpor. Akan diterapkan pada operasi impor beatmap selanjutnya.</string>
 
-    <string name="opt_delete_unsupported_videos_title">Delete unsupported videos</string>
-    <string name="opt_delete_unsupported_videos_summary">Delete videos with unsupported formats (.avi and .flv)</string>
+    <string name="opt_delete_unsupported_videos_title">Hapus video yang tidak didukung</string>
+    <string name="opt_delete_unsupported_videos_summary">Hapus video dengan format yang tidak didukung (.avi dan .flv)</string>
 
-    <string name="opt_import_replay_title">Import replay</string>
-    <string name="opt_import_replay_summary">Import a replay file (.odr) or an exported replay file (.edr). Only .odr files from osu!droid version 1.6.7 onwards are supported</string>
+    <string name="opt_import_replay_title">Impor replay</string>
+    <string name="opt_import_replay_summary">Impor file replay (.odr) atau file replay yang diekspor (.edr). Hanya file .odr dari versi osu!droid 1.6.7 ke atas yang didukung</string>
 
     <!-- Metadata -->
     <string name="opt_category_metadata">Metadata</string>
     <string name="force_romanized">Gunakan metadata yang diromanisasi</string>
-    <string name="force_romanized_summary">Penggunaan karakter roman untuk metadata, apabila judul dalam bahasa Jepang atau China tidak dapat dibaca</string>
+    <string name="force_romanized_summary">Gunakan karakter romaji untuk metadata, jika judul dalam bahasa Jepang atau Cina tidak dapat dibaca</string>
 
     <!-- Storage -->
-    <string name="opt_category_storage">Storage</string>
-    <string name="opt_clear_title">Bersihkan cache perpustakaan</string>
-    <string name="opt_clear_summary">Pembersihan cache perpustakaan secara paksa</string>
+    <string name="opt_category_storage">Penyimpanan</string>
+    <string name="opt_clear_title">Hapus cache perpustakaan</string>
+    <string name="opt_clear_summary">Hapus cache perpustakaan secara paksa</string>
 
-    <string name="opt_clearprops_title">Bersihkan data spesifik tiap map</string>
-    <string name="opt_clearprops_summary">Bersihkan seluruh map dengan data spesifik secara paksa (seperti offset tiap map)</string>
+    <string name="opt_clearprops_title">Hapus data khusus tiap map</string>
+    <string name="opt_clearprops_summary">Hapus semua data khusus tiap map secara paksa (seperti offset tiap map)</string>
 
 <!-- Input -->
     <!-- Gameplay -->
     <string name="opt_category_gameplay">Gameplay</string>
 
-    <string name="block_area_preference_title">Manage input block areas</string>
-    <string name="block_area_preference_summary">Manage specific areas within the screen where presses will be ignored during gameplay</string>
+    <string name="block_area_preference_title">Kelola area blok input</string>
+    <string name="block_area_preference_summary">Kelola area tertentu pada layar di mana tekanan akan diabaikan selama permainan</string>
 
-    <string name="opt_backButtonPressTime_title">Back button press time</string>
-    <string name="opt_backButtonPressTime_summary">Required time in milliseconds to action the on-screen back button</string>
+    <string name="opt_backButtonPressTime_title">Waktu tekan tombol kembali</string>
+    <string name="opt_backButtonPressTime_summary">Waktu yang diperlukan (dalam milidetik) untuk menanggapi tombol kembali di layar</string>
 
-    <string name="opt_seekBarVibrateIntensity_title">Set Intensity</string>
-    <string name="opt_seekBarVibrateIntensity_summary">Change the intensity of the vibration</string>
+    <string name="opt_seekBarVibrateIntensity_title">Atur intensitas getaran</string>
+    <string name="opt_seekBarVibrateIntensity_summary">Ubah intensitas getaran</string>
 
     <!-- Synchronisation  -->
-    <string name="opt_category_synchronization">Synchronization</string>
+    <string name="opt_category_synchronization">Sinkronisasi</string>
 
-    <string name="opt_fix_frame_offset_title">Perbaiki offset acak</string>
-    <string name="opt_fix_frame_offset_summary">Memperbaiki offset antara waktu input and waktu frame.</string>
+    <string name="opt_fix_frame_offset_title">Perbaiki offset frame</string>
+    <string name="opt_fix_frame_offset_summary">Memperbaiki offset antara waktu input dan waktu frame.</string>
 
 <!-- Advanced -->
     <!-- Directories -->
-    <string name="opt_category_directories">Directories</string>
+    <string name="opt_category_directories">Direktori</string>
     <string name="opt_corepath_title">Direktori utama</string>
     <string name="opt_corepath_summary">Direktori utama osu!droid</string>
 
-    <string name="opt_skin_top_path_title">Direktori skin</string>
-    <string name="opt_skin_top_path_summary">Jalan ke direktori berisi file tema (standar: /sdcard/osu!droid/Skin)</string>
+    <string name="opt_skin_top_path_title">Direktori tema</string>
+    <string name="opt_skin_top_path_summary">Jalur menuju direktori yang berisi file tema (standar: /sdcard/osu!droid/Skin)</string>
 
     <string name="opt_directory_title">Lokasi beatmap</string>
-    <string name="opt_directory_summary">Jalan menuju direktori berisi beatmap (standar: /mnt/sdcard/osu!droid/Songs)</string>
+    <string name="opt_directory_summary">Jalur menuju direktori yang berisi beatmap (standar: /mnt/sdcard/osu!droid/Songs)</string>
 
     <!-- Miscellaneous -->
-    <string name="opt_force_max_refresh_rate_title">Force maximum refresh rate</string>
-    <string name="opt_force_max_refresh_rate_summary">Attempts to force the maximum refresh rate of the device to be used. Disable if you experience screen flickering.</string>
+    <string name="opt_force_max_refresh_rate_title">Paksa kecepatan refresh maksimum</string>
+    <string name="opt_force_max_refresh_rate_summary">Mencoba memaksa penggunaan kecepatan refresh maksimum perangkat. Nonaktifkan jika mengalami kedip layar.</string>
 
-    <string name="opt_safe_beatmap_bg_title">Safe beatmap background</string>
-    <string name="opt_safe_beatmap_bg_summary">Change all of the beatmaps\' background to the menu-background image from your skin</string>
+    <string name="opt_safe_beatmap_bg_title">Latar belakang beatmap aman</string>
+    <string name="opt_safe_beatmap_bg_summary">Ubah semua latar belakang beatmap menjadi gambar latar belakang menu dari tema Anda</string>
 
 <!-- All new strings should present below for better managing locals... -->
 


### PR DESCRIPTION
# 📝 Localized UI Strings to Indonesian

## ✅ Changes

- Translated all `<string>` and `<string-array>` entries from English into natural Indonesian
- Preserved technical terms (e.g., `osu!droid`, `mod`, `beatmap`, `HUD`, `FPS`, `Storyboard`) in English
- Left comments (`<!-- ... -->`) unchanged
- Applied consistent terminology across all strings (e.g., "pembaruan" for update, "akun" for account, "bahasa" for language)
- Ensured formal, clear, and user-friendly Indonesian style following EYD rules

---

## 💡 Motivation

- Improve accessibility for Indonesian-speaking users  
- Provide a more natural and localized experience while maintaining technical accuracy  
- Keep consistency with other localized versions of osu!droid

---

## 🔍 Example

### Before:
```xml
<string name="opt_global_beatmap_leaderboard_scoring_mode_title">Global beatmap leaderboard scoring mode</string>
<string name="opt_global_beatmap_leaderboard_scoring_mode_summary">Choose the scoring mode for global beatmap leaderboards</string>
```

### After:
```xml
<string name="opt_global_beatmap_leaderboard_scoring_mode_title">Mode penilaian papan peringkat beatmap global</string>
<string name="opt_global_beatmap_leaderboard_scoring_mode_summary">Pilih mode penilaian untuk papan peringkat beatmap global</string>
```

---